### PR TITLE
Templated Tangent group for general groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Lie++ is a header-only C++ library based on Eigen for Lie groups. It provides a 
 | SE(3)        | Pose                              |
 | SE2(3)       | Extended pose                     |
 | SEn(3)       | SLAM                              |
+| G(3)         | Discrete-time IMU preintegration  |
 | SOT(3)       | Rotation and scaling              |
 | TG(3)        | Inertial navigation with IMU bias |
 | SDB(3)       | Inertial navigation with IMU bias |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Lie++ is a header-only C++ library based on Eigen for Lie groups. It provides a 
 | SE(3)        | Pose                              |
 | SE2(3)       | Extended pose                     |
 | SEn(3)       | SLAM                              |
-| G(3)         | Discrete-time IMU preintegration  |
+| G(3)         | Discrete-time Inertial navigation |
 | SOT(3)       | Rotation and scaling              |
 | TG(3)        | Inertial navigation with IMU bias |
 | SDB(3)       | Inertial navigation with IMU bias |


### PR DESCRIPTION
Generalization of the Tangent Group class:
- Templated `TG.hpp` for usage with any group
- Created derived classes `SEn3TG` and `G3TG` for the tangent groups of SEn3 and G3
- Added specific tests for `SE23TG` and `G3TG` and tested
- Updated readme including the _Inhomogeneous Galileian Lie group_ G(3)