### PR TITLE
[ADD] Added closed-form formulas for the inverse left (and right) Jacobians.

### DIFF
--- a/include/groups/SDB.hpp
+++ b/include/groups/SDB.hpp
@@ -77,7 +77,7 @@ class SemiDirectBias
   {
     VectorType u = VectorType::Zero();
     u.template block<9, 1>(0, 0) = SE23Type::log(X.D_);
-    u.template block<6, 1>(9, 0) = (SE3Type::leftJacobian(u.template block<6, 1>(0, 0))).inverse() * X.delta_;
+    u.template block<6, 1>(9, 0) = (SE3Type::invLeftJacobian(u.template block<6, 1>(0, 0))) * X.delta_;
     return u;
   }
 

--- a/include/groups/SO3.hpp
+++ b/include/groups/SO3.hpp
@@ -172,6 +172,27 @@ class SO3
   }
 
   /**
+   * @brief SO3 inverse left Jacobian matrix
+   *
+   * @param u R3 vector
+   *
+   * @return SO3 inverse left Jacobian matrix
+   */
+  [[nodiscard]] static const TMatrixType invLeftJacobian(const VectorType& u)
+  {
+    FPType ang = u.norm();
+    if (ang < eps_)
+    {
+      return TMatrixType::Identity() - 0.5 * wedge(u);
+    }
+    VectorType ax = u / ang;
+    FPType half_ang = 0.5 * ang;
+    FPType cot = 1.0 / tan(half_ang);
+    return (half_ang * cot) * TMatrixType::Identity() + (1.0 - half_ang * cot) * ax * ax.transpose() -
+           half_ang * wedge(ax);
+  }
+
+  /**
    * @brief SO3 right Jacobian matrix
    *
    * @param u R3 vector
@@ -179,6 +200,15 @@ class SO3
    * @return SO3 right Jacobian matrix
    */
   [[nodiscard]] static const TMatrixType rightJacobian(const VectorType& u) { return leftJacobian(-u); }
+
+  /**
+   * @brief SO3 inverse right Jacobian matrix
+   *
+   * @param u R3 vector
+   *
+   * @return SO3 inverse right Jacobian matrix
+   */
+  [[nodiscard]] static const TMatrixType invRightJacobian(const VectorType& u) { return invLeftJacobian(-u); }
 
   /**
    * @brief The exponential map for SO3.

--- a/include/groups/SOT3.hpp
+++ b/include/groups/SOT3.hpp
@@ -147,6 +147,20 @@ class SOT3
   }
 
   /**
+   * @brief SOT3 inverse left Jacobian matrix
+   *
+   * @param u R4 vector
+   *
+   * @return SOT3 inverse left Jacobian matrix
+   */
+  [[nodiscard]] static const TMatrixType invLeftJacobian(const VectorType& u)
+  {
+    TMatrixType J = TMatrixType::Identity();
+    J.template block<3, 3>(0, 0) = SO3Type::invLeftJacobian(u.template block<3, 1>(0, 0));
+    return J;
+  }
+
+  /**
    * @brief SOT3 right Jacobian matrix
    *
    * @param u R4 vector
@@ -154,6 +168,15 @@ class SOT3
    * @return SOT3 right Jacobian matrix
    */
   [[nodiscard]] static const TMatrixType rightJacobian(const VectorType& u) { return leftJacobian(-u); }
+
+  /**
+   * @brief SOT3 inverse right Jacobian matrix
+   *
+   * @param u R4 vector
+   *
+   * @return SOT3 inverse right Jacobian matrix
+   */
+  [[nodiscard]] static const TMatrixType invRightJacobian(const VectorType& u) { return invLeftJacobian(-u); }
 
   /**
    * @brief The exponential map for SOT3.

--- a/include/groups/TG.hpp
+++ b/include/groups/TG.hpp
@@ -78,7 +78,7 @@ class Tangent
   {
     VectorType u = VectorType::Zero();
     u.template block<N, 1>(0, 0) = Group::log(X.G_);
-    u.template block<N, 1>(N, 0) = (Group::leftJacobian(u.template block<N, 1>(0, 0))).inverse() * X.g_;
+    u.template block<N, 1>(N, 0) = (Group::invLeftJacobian(u.template block<N, 1>(0, 0))) * X.g_;
     return u;
   }
 

--- a/tests/test_groups.hpp
+++ b/tests/test_groups.hpp
@@ -218,6 +218,32 @@ TYPED_TEST(G3GroupsTest, TestLeftJacobian)
     adx = TypeParam::adjoint(x);
     Jlx = TypeParam::leftJacobian(x);
     MatrixEquality(AdEx, TypeParam::TMatrixType::Identity() + adx * Jlx);
+
+    x = 1e-12 * TypeParam::VectorType::Random();
+    Jlx = TypeParam::leftJacobian(x);
+    auto invJlx = TypeParam::invLeftJacobian(x);
+    MatrixEquality(Jlx * invJlx, TypeParam::TMatrixType::Identity());
+
+    x = TypeParam::VectorType::Random();
+    Jlx = TypeParam::leftJacobian(x);
+    invJlx = TypeParam::invLeftJacobian(x);
+    MatrixEquality(Jlx * invJlx, TypeParam::TMatrixType::Identity());
+  }
+}
+
+TYPED_TEST(G3GroupsTest, TestRightJacobian)
+{
+  for (int i = 0; i < N_TESTS; ++i)
+  {
+    typename TypeParam::VectorType x = 1e-12 * TypeParam::VectorType::Random();
+    auto Jrx = TypeParam::rightJacobian(x);
+    auto invJrx = TypeParam::invRightJacobian(x);
+    MatrixEquality(Jrx * invJrx, TypeParam::TMatrixType::Identity());
+
+    x = TypeParam::VectorType::Random();
+    Jrx = TypeParam::rightJacobian(x);
+    invJrx = TypeParam::invRightJacobian(x);
+    MatrixEquality(Jrx * invJrx, TypeParam::TMatrixType::Identity());
   }
 }
 
@@ -992,6 +1018,56 @@ TYPED_TEST(SO3GroupsTest, TestGroupProduct)
   }
 }
 
+TYPED_TEST(SO3GroupsTest, TestLeftJacobian)
+{
+  for (int i = 0; i < N_TESTS; ++i)
+  {
+    typename TypeParam::VectorType x = TypeParam::VectorType::Zero();
+    auto AdEx = TypeParam::exp(x).Adjoint();
+    auto adx = TypeParam::adjoint(x);
+    auto Jlx = TypeParam::leftJacobian(x);
+    MatrixEquality(AdEx, TypeParam::TMatrixType::Identity() + adx * Jlx);
+
+    x = 1e-12 * TypeParam::VectorType::Random();
+    AdEx = TypeParam::exp(x).Adjoint();
+    adx = TypeParam::adjoint(x);
+    Jlx = TypeParam::leftJacobian(x);
+    MatrixEquality(AdEx, TypeParam::TMatrixType::Identity() + adx * Jlx);
+
+    x = TypeParam::VectorType::Random();
+    AdEx = TypeParam::exp(x).Adjoint();
+    adx = TypeParam::adjoint(x);
+    Jlx = TypeParam::leftJacobian(x);
+    MatrixEquality(AdEx, TypeParam::TMatrixType::Identity() + adx * Jlx);
+
+    x = 1e-12 * TypeParam::VectorType::Random();
+    Jlx = TypeParam::leftJacobian(x);
+    auto invJlx = TypeParam::invLeftJacobian(x);
+    MatrixEquality(Jlx * invJlx, TypeParam::TMatrixType::Identity());
+
+    x = TypeParam::VectorType::Random();
+    Jlx = TypeParam::leftJacobian(x);
+    invJlx = TypeParam::invLeftJacobian(x);
+    MatrixEquality(Jlx * invJlx, TypeParam::TMatrixType::Identity());
+  }
+}
+
+TYPED_TEST(SO3GroupsTest, TestRightJacobian)
+{
+  for (int i = 0; i < N_TESTS; ++i)
+  {
+    typename TypeParam::VectorType x = 1e-12 * TypeParam::VectorType::Random();
+    auto Jrx = TypeParam::rightJacobian(x);
+    auto invJrx = TypeParam::invRightJacobian(x);
+    MatrixEquality(Jrx * invJrx, TypeParam::TMatrixType::Identity());
+
+    x = TypeParam::VectorType::Random();
+    Jrx = TypeParam::rightJacobian(x);
+    invJrx = TypeParam::invRightJacobian(x);
+    MatrixEquality(Jrx * invJrx, TypeParam::TMatrixType::Identity());
+  }
+}
+
 /**
  * @brief SOT3 specific tests
  */
@@ -1143,6 +1219,56 @@ TYPED_TEST(SOT3GroupsTest, TestGroupProduct)
     auto Z = X * Y;
 
     MatrixEquality(Z, X.asMatrix() * Y);
+  }
+}
+
+TYPED_TEST(SOT3GroupsTest, TestLeftJacobian)
+{
+  for (int i = 0; i < N_TESTS; ++i)
+  {
+    typename TypeParam::VectorType x = TypeParam::VectorType::Zero();
+    auto AdEx = TypeParam::exp(x).Adjoint();
+    auto adx = TypeParam::adjoint(x);
+    auto Jlx = TypeParam::leftJacobian(x);
+    MatrixEquality(AdEx, TypeParam::TMatrixType::Identity() + adx * Jlx);
+
+    x = 1e-12 * TypeParam::VectorType::Random();
+    AdEx = TypeParam::exp(x).Adjoint();
+    adx = TypeParam::adjoint(x);
+    Jlx = TypeParam::leftJacobian(x);
+    MatrixEquality(AdEx, TypeParam::TMatrixType::Identity() + adx * Jlx);
+
+    x = TypeParam::VectorType::Random();
+    AdEx = TypeParam::exp(x).Adjoint();
+    adx = TypeParam::adjoint(x);
+    Jlx = TypeParam::leftJacobian(x);
+    MatrixEquality(AdEx, TypeParam::TMatrixType::Identity() + adx * Jlx);
+
+    x = 1e-12 * TypeParam::VectorType::Random();
+    Jlx = TypeParam::leftJacobian(x);
+    auto invJlx = TypeParam::invLeftJacobian(x);
+    MatrixEquality(Jlx * invJlx, TypeParam::TMatrixType::Identity());
+
+    x = TypeParam::VectorType::Random();
+    Jlx = TypeParam::leftJacobian(x);
+    invJlx = TypeParam::invLeftJacobian(x);
+    MatrixEquality(Jlx * invJlx, TypeParam::TMatrixType::Identity());
+  }
+}
+
+TYPED_TEST(SOT3GroupsTest, TestRightJacobian)
+{
+  for (int i = 0; i < N_TESTS; ++i)
+  {
+    typename TypeParam::VectorType x = 1e-12 * TypeParam::VectorType::Random();
+    auto Jrx = TypeParam::rightJacobian(x);
+    auto invJrx = TypeParam::invRightJacobian(x);
+    MatrixEquality(Jrx * invJrx, TypeParam::TMatrixType::Identity());
+
+    x = TypeParam::VectorType::Random();
+    Jrx = TypeParam::rightJacobian(x);
+    invJrx = TypeParam::invRightJacobian(x);
+    MatrixEquality(Jrx * invJrx, TypeParam::TMatrixType::Identity());
   }
 }
 
@@ -1363,6 +1489,32 @@ TYPED_TEST(SEn3GroupsTest, TestLeftJacobian)
     adx = TypeParam::adjoint(x);
     Jlx = TypeParam::leftJacobian(x);
     MatrixEquality(AdEx, TypeParam::TMatrixType::Identity() + adx * Jlx);
+
+    x = 1e-12 * TypeParam::VectorType::Random();
+    Jlx = TypeParam::leftJacobian(x);
+    auto invJlx = TypeParam::invLeftJacobian(x);
+    MatrixEquality(Jlx * invJlx, TypeParam::TMatrixType::Identity());
+
+    x = TypeParam::VectorType::Random();
+    Jlx = TypeParam::leftJacobian(x);
+    invJlx = TypeParam::invLeftJacobian(x);
+    MatrixEquality(Jlx * invJlx, TypeParam::TMatrixType::Identity());
+  }
+}
+
+TYPED_TEST(SEn3GroupsTest, TestRightJacobian)
+{
+  for (int i = 0; i < N_TESTS; ++i)
+  {
+    typename TypeParam::VectorType x = 1e-12 * TypeParam::VectorType::Random();
+    auto Jrx = TypeParam::rightJacobian(x);
+    auto invJrx = TypeParam::invRightJacobian(x);
+    MatrixEquality(Jrx * invJrx, TypeParam::TMatrixType::Identity());
+
+    x = TypeParam::VectorType::Random();
+    Jrx = TypeParam::rightJacobian(x);
+    invJrx = TypeParam::invRightJacobian(x);
+    MatrixEquality(Jrx * invJrx, TypeParam::TMatrixType::Identity());
   }
 }
 


### PR DESCRIPTION
- Added `invLeftJacobian(u)` and `invRightJaobian(u)` functions for `SO3`, `SOT3`, `SEn3`, `G3`. This implementation is more efficient than the generic `Eigen::inverse()`.
- Added tests for all groups and tested.